### PR TITLE
Add DI loaded cache service

### DIFF
--- a/src/features/cache.feature
+++ b/src/features/cache.feature
@@ -1,0 +1,14 @@
+Feature: Cache service
+
+  As a user I want to be able to get, set and increment
+  a value in a cache service
+
+  Scenario: I request a non existing key from cache
+  Given There's no such key as "testkey"
+  When I request the key "testkey"
+  Then I get a null response
+
+  Scenario: I request a existing key from cache
+  Given I set cache key "testkey" to "666"
+  When I request the key "testkey"
+  Then I get a "666" response

--- a/src/features/cache.feature
+++ b/src/features/cache.feature
@@ -12,3 +12,21 @@ Feature: Cache service
   Given I set cache key "testkey" to "666"
   When I request the key "testkey"
   Then I get a "666" response
+
+  Scenario: I increment an existing key in cache
+  Given I set cache key "testkey" to "666"
+  Given I increment cache key "testkey" by "1"
+  When I request the key "testkey"
+  Then I get a "667" response
+
+  Scenario: I increment a non-existing key in cache
+  Given There's no such key as "testkey"
+  Given I increment cache key "testkey" by "1"
+  When I request the key "testkey"
+  Then I get a "1" response
+
+  Scenario: I increment an existing non-numeric key in cache
+  Given I set cache key "testkey" to "test"
+  Given I increment cache key "testkey" by "1"
+  When I request the key "testkey"
+  Then I get an error response

--- a/src/features/steps/cache.js
+++ b/src/features/steps/cache.js
@@ -20,7 +20,12 @@ export default function () {
 	});
 
 	this.Given(/^I increment cache key "([^"]*)" by "([^"]*)"$/, function (cacheKey, addedValue, callback) {
-		callback(null, 'pending');
+		this.context.cache.increment(cacheKey, addedValue).then(() => {
+			callback();
+		}, (err) => {
+		this.context.cacheError = err;
+			callback();
+		});
 	});
 
 	this.When(/^I request the key "([^"]*)"$/, function (testKey, callback) {
@@ -45,8 +50,8 @@ export default function () {
 		assert.strictEqual(parseInt(this.context.cacheResponse, 10), parseInt(response, 10), "Cache value does not match");
 	});
 
-	this.Then(/^I get an error response$/, function (callback) {
-		callback(null, 'pending');
+	this.Then(/^I get an error response$/, function () {
+		assert.instanceOf(this.context.cacheError, Error, 'Error getting error');
 	});
 
 }

--- a/src/features/steps/cache.js
+++ b/src/features/steps/cache.js
@@ -5,22 +5,25 @@ import { assert } from 'chai';
 export default function () {
 
 	this.Before(function () {
-		this.context.cache = this.container.get('cache');
+		// this.context.cache = this.container.get('cache');
 	});
 
 	this.Given(/^There's no such key as "([^"]*)"$/, function (key, callback) {
-		this.context.cache.remove(key);
+		const cache = this.container.get('cache');
+		cache.remove(key);
 		callback();
 	});
 
 	this.Given(/^I set cache key "([^"]*)" to "([^"]*)"$/, function (key, value, callback) {
-		this.context.cache.set(key, value).then(() => {
+		const cache = this.container.get('cache');
+		cache.set(key, value).then(() => {
 			callback();
 		}, callback);
 	});
 
 	this.Given(/^I increment cache key "([^"]*)" by "([^"]*)"$/, function (cacheKey, addedValue, callback) {
-		this.context.cache.increment(cacheKey, addedValue).then(() => {
+		const cache = this.container.get('cache');
+		cache.increment(cacheKey, addedValue).then(() => {
 			callback();
 		}, (err) => {
 		this.context.cacheError = err;
@@ -29,7 +32,8 @@ export default function () {
 	});
 
 	this.When(/^I request the key "([^"]*)"$/, function (testKey, callback) {
-		this.context.cache.get(testKey).then((cacheResponse) => {
+		const cache = this.container.get('cache');
+		cache.get(testKey).then((cacheResponse) => {
 				this.context.cacheResponse = cacheResponse;
 				callback();
 			},

--- a/src/features/steps/cache.js
+++ b/src/features/steps/cache.js
@@ -1,0 +1,25 @@
+'use strict';
+
+export default function () {
+
+	this.Given(/^There's no such key as "([^"]*)"$/, function (key, callback) {
+		callback(null, 'pending');
+	});
+
+	this.Given(/^I set cache key "([^"]*)" to "([^"]*)"$/, function (key, value, callback) {
+		callback(null, 'pending');
+	});
+
+	this.When(/^I request the key "([^"]*)"$/, function (testKey, callback) {
+		callback(null, 'pending');
+	});
+
+	this.Then(/^I get a null response$/, function (callback) {
+		callback(null, 'pending');
+	});
+
+	this.Then(/^I get a "([^"]*)" response$/, function (response, callback) {
+		callback(null, 'pending');
+	});
+
+}

--- a/src/features/steps/cache.js
+++ b/src/features/steps/cache.js
@@ -41,12 +41,12 @@ export default function () {
 	});
 
 	this.Then(/^I get a null response$/, function () {
-		assert.strictEqual(this.context.cacheError, undefined, "Error getting cache key");
+		assert.notInstanceOf(this.context.cacheError, Error, "Error getting cache key");
 		assert.strictEqual(this.context.cacheResponse, null, "Response not null");
 	});
 
 	this.Then(/^I get a "([^"]*)" response$/, function (response) {
-		assert.isUndefined(this.context.cacheError, "Error getting cache key");
+		assert.notInstanceOf(this.context.cacheError, Error, "Error getting cache key");
 		assert.strictEqual(parseInt(this.context.cacheResponse, 10), parseInt(response, 10), "Cache value does not match");
 	});
 

--- a/src/features/steps/cache.js
+++ b/src/features/steps/cache.js
@@ -1,25 +1,43 @@
 'use strict';
 
+import { assert } from 'chai';
+
 export default function () {
 
+	this.Before(function () {
+		this.context.cache = this.container.get('cache');
+	});
+
 	this.Given(/^There's no such key as "([^"]*)"$/, function (key, callback) {
-		callback(null, 'pending');
+		callback();
 	});
 
 	this.Given(/^I set cache key "([^"]*)" to "([^"]*)"$/, function (key, value, callback) {
-		callback(null, 'pending');
+		this.context.cache.set(key, value).then(() => {
+			callback();
+		}, callback);
 	});
 
 	this.When(/^I request the key "([^"]*)"$/, function (testKey, callback) {
-		callback(null, 'pending');
+		this.context.cache.get(testKey).then((cacheResponse) => {
+				this.context.cacheResponse = cacheResponse;
+				callback();
+			},
+			(cacheError) => {
+				this.context.cacheError = cacheError;
+				callback();
+			}
+		);
 	});
 
-	this.Then(/^I get a null response$/, function (callback) {
-		callback(null, 'pending');
+	this.Then(/^I get a null response$/, function () {
+		assert.strictEqual(this.context.cacheError, undefined, "Error getting cache key");
+		assert.strictEqual(this.context.cacheResponse, null, "Response not null");
 	});
 
-	this.Then(/^I get a "([^"]*)" response$/, function (response, callback) {
-		callback(null, 'pending');
+	this.Then(/^I get a "([^"]*)" response$/, function (response) {
+		assert.isUndefined(this.context.cacheError, "Error getting cache key");
+		assert.strictEqual(parseInt(this.context.cacheResponse, 10), parseInt(response, 10), "Cache value does not match");
 	});
 
 }

--- a/src/features/steps/cache.js
+++ b/src/features/steps/cache.js
@@ -9,6 +9,7 @@ export default function () {
 	});
 
 	this.Given(/^There's no such key as "([^"]*)"$/, function (key, callback) {
+		this.context.cache.remove(key);
 		callback();
 	});
 
@@ -16,6 +17,10 @@ export default function () {
 		this.context.cache.set(key, value).then(() => {
 			callback();
 		}, callback);
+	});
+
+	this.Given(/^I increment cache key "([^"]*)" by "([^"]*)"$/, function (cacheKey, addedValue, callback) {
+		callback(null, 'pending');
 	});
 
 	this.When(/^I request the key "([^"]*)"$/, function (testKey, callback) {
@@ -38,6 +43,10 @@ export default function () {
 	this.Then(/^I get a "([^"]*)" response$/, function (response) {
 		assert.isUndefined(this.context.cacheError, "Error getting cache key");
 		assert.strictEqual(parseInt(this.context.cacheResponse, 10), parseInt(response, 10), "Cache value does not match");
+	});
+
+	this.Then(/^I get an error response$/, function (callback) {
+		callback(null, 'pending');
 	});
 
 }

--- a/src/features/support/world.js
+++ b/src/features/support/world.js
@@ -18,7 +18,7 @@ function World() {
 }
 
 function setupConfig(config) {
-  //config.update('service', 'memory');
+  config.update('cache', 'memory');
 }
 
 function extendContainer() {

--- a/src/server/container.js
+++ b/src/server/container.js
@@ -5,6 +5,6 @@ const di = diTools.getDI();
 di.registerModule(require('lab-config'), 'config');
 di.registerModule(require('lab-config/implementations/memory'), 'config-memory');
 
-//diTools.registerDir(path.resolve(__dirname, 'external'));
+diTools.registerDir(path.resolve(__dirname, 'external'));
 
 export default di;

--- a/src/server/external/cache/executors/atoint.js
+++ b/src/server/external/cache/executors/atoint.js
@@ -1,0 +1,7 @@
+export default function atoint (numString) {
+	const retval = parseInt(numString, 10)
+	if (isNaN(retval)) {
+		throw new Error("Cannot convert " + numString + " to number")
+	}
+	return retval
+}

--- a/src/server/external/cache/executors/atoint.test.js
+++ b/src/server/external/cache/executors/atoint.test.js
@@ -1,0 +1,24 @@
+/* global describe, it, expect */
+import atoint from './atoint'
+
+const numNumber = 123
+const numString = "123"
+const numFloat = 123.723
+const invalidString = "onetwothree"
+
+describe('atoint', () => {
+	it('should parse a number stored as a string', () => {
+		expect(atoint(numString)).toBe(123)
+	})
+	it('should parse a number stored as a number', () => {
+		expect(atoint(numNumber)).toBe(123)
+	})
+	it('should return a float as an integer', () => {
+		expect(atoint(numFloat)).toBe(123)
+	})
+	it('should throw an error when converting non-numeric strings', () => {
+		expect(() => {
+			atoint(invalidString)
+		}).toThrow()
+	})
+})

--- a/src/server/external/cache/executors/incrementby.js
+++ b/src/server/external/cache/executors/incrementby.js
@@ -1,0 +1,3 @@
+export default function incrementBy (origValue, addedValue) {
+	return origValue + addedValue
+}

--- a/src/server/external/cache/executors/incrementby.test.js
+++ b/src/server/external/cache/executors/incrementby.test.js
@@ -1,0 +1,8 @@
+/* global describe, it, expect */
+import incrementBy from './incrementBy'
+
+describe('incrementBy', () => {
+	it('should increment the original value by amount', () => {
+		expect(incrementBy(1, 1)).toBe(2)
+	})
+})

--- a/src/server/external/cache/implementations/memory.js
+++ b/src/server/external/cache/implementations/memory.js
@@ -1,5 +1,12 @@
 'use strict'
 
 module.exports = function() {
-	return Object.freeze({});
+
+	const cache = {}
+
+	const get = async (key) => cache[key] || null
+
+	return Object.freeze({
+		get
+	});
 }

--- a/src/server/external/cache/implementations/memory.js
+++ b/src/server/external/cache/implementations/memory.js
@@ -1,5 +1,8 @@
 'use strict'
 
+import atoint from '../executors/atoint'
+import incrementBy from '../executors/incrementby';
+
 module.exports = function() {
 
 	const cache = {}
@@ -15,9 +18,16 @@ module.exports = function() {
 		delete cache[key]
 	}
 
+	const increment = async (key, amount) => {
+		const origValue = await get(key) || 0
+		const newVal = incrementBy(atoint(origValue), atoint(amount))
+		return set(key, newVal)
+	}
+
 	return Object.freeze({
 		get,
 		set,
-		remove
+		remove,
+		increment
 	});
 }

--- a/src/server/external/cache/implementations/memory.js
+++ b/src/server/external/cache/implementations/memory.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = function() {
+	return Object.freeze({});
+}

--- a/src/server/external/cache/implementations/memory.js
+++ b/src/server/external/cache/implementations/memory.js
@@ -11,8 +11,13 @@ module.exports = function() {
 		return value
 	}
 
+	const remove = async (key) => {
+		delete cache[key]
+	}
+
 	return Object.freeze({
 		get,
-		set
+		set,
+		remove
 	});
 }

--- a/src/server/external/cache/implementations/memory.js
+++ b/src/server/external/cache/implementations/memory.js
@@ -6,7 +6,13 @@ module.exports = function() {
 
 	const get = async (key) => cache[key] || null
 
+	const set = async (key, value) => {
+		cache[key] = value
+		return value
+	}
+
 	return Object.freeze({
-		get
+		get,
+		set
 	});
 }

--- a/src/server/external/cache/implementations/redis.js
+++ b/src/server/external/cache/implementations/redis.js
@@ -11,8 +11,13 @@ module.exports = function() {
 		return value
 	}
 
+	const remove = async (key) => {
+		redis.del(key)
+	}
+
 	return Object.freeze({
 		get,
-		set
+		set,
+		remove
 	});
 }

--- a/src/server/external/cache/implementations/redis.js
+++ b/src/server/external/cache/implementations/redis.js
@@ -1,5 +1,18 @@
 'use strict'
 
 module.exports = function() {
-	return Object.freeze({});
+
+	const redis = new require('ioredis')();
+
+	const get = async (key) => redis.get(key)
+
+	const set = async (key, value) => {
+		redis.set(key, value)
+		return value
+	}
+
+	return Object.freeze({
+		get,
+		set
+	});
 }

--- a/src/server/external/cache/implementations/redis.js
+++ b/src/server/external/cache/implementations/redis.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = function() {
+	return Object.freeze({});
+}

--- a/src/server/external/cache/implementations/redis.js
+++ b/src/server/external/cache/implementations/redis.js
@@ -15,9 +15,14 @@ module.exports = function() {
 		redis.del(key)
 	}
 
+	const increment = async (key, amount) => {
+		return await redis.incrby(key, parseInt(amount, 10))
+	}
+
 	return Object.freeze({
 		get,
 		set,
-		remove
+		remove,
+		increment
 	});
 }

--- a/src/server/external/cache/index.js
+++ b/src/server/external/cache/index.js
@@ -1,0 +1,6 @@
+function CacheService(container) {
+	const implementation = container.config.get('cache') || 'redis';
+	return container.getImplementation('cache', implementation);
+}
+CacheService.type = 'factory';
+module.exports = CacheService;


### PR DESCRIPTION
### What does this PR do? How does it affect users?
Implements a new cache service in both Redis and memory. The service supports basic commands:
```javascript
get(key: string): string
set(key: string, value: T): T
remove(key: string)
increment(key: string, amount: number|string): number
```

The service is loaded through the `lab-di` DI loader tool, to use it from the server DI container:
```javascript
const cache = this.container.get('cache');
const cachedValue = cache.get('sup');
```

### How should this be tested (feature switches, URLs, special user permissions)?
The cache itself is not accessed in anywhere from the code, except from tests.

### Relevant test coverage if applicable
The cache services behaviour is tested in `features/cache.feature`, to run them: `npm run test`

BDD tests run using the memory implementation, to switch to using Redis instead change `memory` to `redis` in `src/features/support/world.js`:
```javascript
function setupConfig(config) {
    config.update('cache', 'memory');
}
```

The services inside has unit tests, to run them: `npm run test:unit` 


### Related Asana task, wiki page or blog posts
Greenfox homework #2: https://andrassy66.slack.com/files/aniko/F3U4V8DTK/homework_for_week_1.txt